### PR TITLE
Fixed typo in prog2 makefile

### DIFF
--- a/prog2_vecintrin/Makefile
+++ b/prog2_vecintrin/Makefile
@@ -3,7 +3,7 @@ all: myexp
 logger.o: logger.cpp logger.h CS149intrin.h CS149intrin.cpp
 	g++ -c logger.cpp
 
-CS348Vintrin.o: CS149intrin.cpp CS149intrin.h logger.cpp logger.h
+CS149intrin.o: CS149intrin.cpp CS149intrin.h logger.cpp logger.h
 	g++ -c CS149intrin.cpp
 
 myexp: CS149intrin.o logger.o main.cpp


### PR DESCRIPTION
This causes student code to fail after simply changing VECTOR_WIDTH and running make (CS149intrin.cpp is not recompiled due to the typo). (I'm a student in the class by the way, I wasn't just doing cs149 assignments in my free time.)